### PR TITLE
Fix interest and fees payment file test coverage

### DIFF
--- a/F2FFeesPaymentFileHandlerTest.cls
+++ b/F2FFeesPaymentFileHandlerTest.cls
@@ -517,6 +517,22 @@ private class F2FFeesPaymentFileHandlerTest {
     }
 
     @isTest
+    static void testClearLoanPaymentTransactions_EmptyInputs() {
+        F2FFeesPaymentFileHandler handler = new F2FFeesPaymentFileHandler();
+        Map<String, Decimal> emptyMap = new Map<String, Decimal>();
+        Set<String> emptySet = new Set<String>();
+        // Should simply return, covering the branch
+        handler.clearLoanPaymentTransactions(emptyMap, emptySet);
+        // Also test with non-empty map and empty set
+        Map<String, Decimal> nonEmptyMap = new Map<String, Decimal>{'Test_Management Fee' => 100.0};
+        handler.clearLoanPaymentTransactions(nonEmptyMap, emptySet);
+        // Also test with empty map and non-empty set
+        Set<String> nonEmptySet = new Set<String>{'Test'};
+        handler.clearLoanPaymentTransactions(emptyMap, nonEmptySet);
+        System.assert(true, 'Method should complete without error for empty inputs.');
+    }
+
+    @isTest
     static void testProcessFeesFileWithMissingHeaders() {
         String fileContent = 'Wrong Header,Another Header\n' +
                             'LAI123,100.00\n';

--- a/F2FInterestPaymentFileHandlerTest.cls
+++ b/F2FInterestPaymentFileHandlerTest.cls
@@ -714,6 +714,14 @@ private class F2FInterestPaymentFileHandlerTest {
         }
     }
 
+    @isTest
+    static void testClearLoanPaymentTransactions_EmptyMap() {
+        F2FInterestPaymentFileHandler handler = new F2FInterestPaymentFileHandler();
+        Map<String, Decimal> emptyMap = new Map<String, Decimal>();
+        handler.clearLoanPaymentTransactions(emptyMap);
+        System.assert(true, 'Method should complete without error for empty input map.');
+    }
+
     //Utility method for unique user creation
     private static User createUniqueTestUser(String testMethodName) {
         List<Profile> systemAdminProfileList = [SELECT Id FROM Profile WHERE Name = 'System Administrator'];

--- a/F2FPaymentFileHelper.cls
+++ b/F2FPaymentFileHelper.cls
@@ -289,6 +289,12 @@ public inherited sharing class F2FPaymentFileHelper {
     * @return True if posting difference is valid, false otherwise
     **/
     public Boolean isPostingDiffValid(loan__Loan_Account__c loanObj, Map<String, Decimal> loanNameVsIOPostingMap) {
+        if (loanObj == null || loanNameVsIOPostingMap == null) {
+            handlerUtilInst.incrementErrorCount(currentFileInstance);
+            handlerUtilInst.addErrorToList(currentFileInstance, handlerUtilInst.getErrorListSize(currentFileInstance) +
+                Folk2FolkConstantValues.TEXT_IN_COMMMA + 'Null argument provided to isPostingDiffValid.' + Folk2FolkConstantValues.NEXT_LINE);
+            return false;
+        }
         // Check if loan has any Investment Order interest postings
         if (!loanNameVsIOPostingMap.containsKey(loanObj.Name)) {
             handlerUtilInst.incrementErrorCount(currentFileInstance);


### PR DESCRIPTION
Improve test coverage for payment file handlers and fix NullPointerException in helper method.

The `clearLoanPaymentTransactions` methods in `F2FFeesPaymentFileHandler` and `F2FInterestPaymentFileHandler` had uncovered early return paths when input maps/sets were empty. New test methods were added to cover these scenarios. Additionally, `F2FPaymentFileHelper.isPostingDiffValid` was throwing a NullPointerException, which is now prevented by adding defensive null checks.

---

[Open in Web](https://www.cursor.com/agents?id=bc-f69ea540-57da-49d1-84bb-1642a96829ed) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f69ea540-57da-49d1-84bb-1642a96829ed)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)